### PR TITLE
feat: integrate nyc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,5 +7,8 @@
                 "corejs": 3
             }
         ]
+    ],
+    "plugins": [
+        "babel-plugin-istanbul"
     ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,20 @@
 version: "3"
 services:
-  app:
-    build:
-      context: .
-      args:
-          ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
-      dockerfile: Dockerfile
-    ports:
-      - "9000:9000"
-    env_file:
-      - .env.local
-    environment:
-      - REDIS_DOMAIN=redis
-      - MONGO_BASE_URI=mongo
-    depends_on:
-      - mongo
+  # app:
+  #   build:
+  #     context: .
+  #     args:
+  #         ENVIRONMENT_NAME: ${ENVIRONMENT_NAME}
+  #     dockerfile: Dockerfile
+  #   ports:
+  #     - "9000:9000"
+  #   env_file:
+  #     - .env.local
+  #   environment:
+  #     - REDIS_DOMAIN=redis
+  #     - MONGO_BASE_URI=mongo
+  #   depends_on:
+  #     - mongo
 
   mongo:
     container_name: mongo

--- a/jest.config.json
+++ b/jest.config.json
@@ -10,7 +10,7 @@
         "!__tests__/__load__/libs/**/*.*"
     ],
     "testRegex": "(/__tests__/.*\\.test)\\.js$",
-    "coverageReporters": ["json-summary", "text", "lcov"],
+    "coverageReporters": ["json", "text", "lcov"],
     "testPathIgnorePatterns": ["<rootDir>/dist/"],
     "moduleNameMapper": {
         "@server(.*)$": "<rootDir>/server/$1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
     "description": "A basic starter web app with node, express and mongoose",
     "main": "index.js",
     "scripts": {
-        "test": "jest --coverage",
+        "e2eTest": "nyc node dist/main.js",
+        "covergae:total": "yarn coverage:merge && yarn coverage:report",
+        "coverage:report": "nyc report --reporter=lcov --reporter=text",
+        "coverage:merge": "mkdir -p ./coverage && nyc merge ./coverage .nyc_output/out.json",
+        "test": "jest --coverage --collectCoverageFrom='src/**/*.{js,jsx}'",
         "start": "node dist/main.js",
         "start:development": "ENVIRONMENT_NAME=development node dist/main.js",
         "build:env": "webpack-cli --config webpack/production.config.js --stats-error-details",
@@ -75,7 +79,7 @@
         "slack-notify": "^2.0.2",
         "swagger-ui-express": "^4.3.0",
         "uuid": "^8.3.2",
-        "webpack": "^5.74.0",
+        "webpack": "^5.91.0",
         "webpack-hot-middleware": "^2.25.2"
     },
     "devDependencies": {
@@ -94,13 +98,32 @@
         "jest-coverage-badges": "^1.1.2",
         "link-module-alias": "^1.2.0",
         "mockingoose": "^2.15.2",
+        "nyc": "^15.1.0",
         "pre-commit": "^1.2.2",
         "prettier": "^2.6.2",
         "prettier-standard": "^16.4.1",
         "regenerator-runtime": "^0.13.9",
         "supertest": "^6.2.2",
         "terser-webpack-plugin": "^5.3.6",
-        "webpack-cli": "^4.10.0"
+        "webpack-cli": "^5.1.4"
+    },
+    "nyc": {
+        "all": true,
+        "include": [
+            "server/**/**.js"
+        ],
+        "exclude": [
+            "**/*.test.js"
+        ],
+        "reporter": [
+            "lcov",
+            "text"
+        ],
+        "extension": [
+            ".js"
+        ],
+        "sourceMap": true,
+        "instrument": true
     },
     "precommit": "lint:staged",
     "lint-staged": {

--- a/server/index.js
+++ b/server/index.js
@@ -53,11 +53,29 @@ app.get('/', (req, res) => {
 });
 list(app);
 
+let server
 if (process.env.NODE_ENV !== 'test') {
-    const server = http.createServer(app);
+    server = http.createServer(app);
     server.listen(app.get('port'), () => {
         log.info('Server is running at port %s', app.get('port'));
     });
 }
+
+function gracefulShutdown(signal) {
+    log.info(`${signal} received`);
+    if (server) {
+        server.close(() => {
+            log.info('HTTP server closed');
+            // Clean up other resources here
+            process.exit(0);
+        });
+    } else {
+        log.info('No server to shut down.');
+        process.exit(0);
+    }
+}
+
+process.on('SIGTERM', gracefulShutdown);
+process.on('SIGINT', gracefulShutdown);
 
 export default app;


### PR DESCRIPTION
### Keploy integration

**Changes** :
Integrated nyc into the code base. Made required changes like graceful shutdown and few other configurations. 

**Step to achieve coverage**:
1. don't run or integrate any sdk.
2. run `yarn test` for getting coverage of unit tests
3. run `keploy test -c "yarn e2eTest"` for coverage of keploy tests
4. To see the coverage of keployTests run  `yarn coverage:report`
5. to get total coverage of keployTests and unit tests run  `yarn coverage:total`